### PR TITLE
Changing the master/slave language

### DIFF
--- a/python/pyrogue_server.py
+++ b/python/pyrogue_server.py
@@ -94,13 +94,13 @@ def exit_message(message):
 def get_host_name():
     return subprocess.check_output("hostname").strip().decode("utf-8")
 
-class DataBuffer(rogue.interfaces.stream.Slave):
+class DataBuffer(rogue.interfaces.stream.Subordinate):
     """
     Data buffer class use to capture data coming from the stream FIFO \
     and copy it into a local buffer using a specific data format.
     """
     def __init__(self, size, data_type):
-        rogue.interfaces.stream.Slave.__init__(self)
+        rogue.interfaces.stream.Subordinate.__init__(self)
         self._buf = [0] * size
 
         # Supported data format and byte order
@@ -278,11 +278,11 @@ class LocalServer(pyrogue.Root):
                         else:
                             fifo_size = stream_pv_size * 4
 
-                        # Setup a FIFO tapped to the stream data and a Slave data buffer
+                        # Setup a FIFO tapped to the stream data and a Subordinate data buffer
                         # Local variables will talk to the data buffer directly.
                         stream_fifo = rogue.interfaces.stream.Fifo(0, fifo_size)
                         data_buffer = DataBuffer(size=stream_pv_size, data_type=stream_pv_type)
-                        stream_fifo._setSlave(data_buffer)
+                        stream_fifo._setSubordinate(data_buffer)
 
                         pyrogue.streamTap(fpga.stream.application(0x80 + i), stream_fifo)
 
@@ -404,7 +404,7 @@ class LocalServer(pyrogue.Root):
                         .format(stream_pv_size,stream_pv_type))
 
                     for i in range(8):
-                        stream_slave = self.epics.createSlave(name="AMCc:Stream{}".format(i), maxSize=stream_pv_size, type=stream_pv_type)
+                        stream_subordinate = self.epics.createSubordinate(name="AMCc:Stream{}".format(i), maxSize=stream_pv_size, type=stream_pv_type)
 
                         # Calculate number of bytes needed on the fifo
                         if '16' in stream_pv_type:
@@ -413,7 +413,7 @@ class LocalServer(pyrogue.Root):
                             fifo_size = stream_pv_size * 4
 
                         stream_fifo = rogue.interfaces.stream.Fifo(0, fifo_size)
-                        stream_fifo._setSlave(stream_slave)
+                        stream_fifo._setSubordinate(stream_subordinate)
                         pyrogue.streamTap(fpga.stream.application(0x80+i), stream_fifo)
 
             self.epics.start()


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.